### PR TITLE
[Fix] Partial Purchase return, Fixes #7390

### DIFF
--- a/erpnext/buying/doctype/purchase_common/purchase_common.js
+++ b/erpnext/buying/doctype/purchase_common/purchase_common.js
@@ -148,7 +148,12 @@ erpnext.buying.BuyingController = erpnext.TransactionController.extend({
 			frappe.model.round_floats_in(item, ["qty", "received_qty"]);
 			item.rejected_qty = flt(item.received_qty - item.qty, precision("rejected_qty", item));
 		}
-
+		
+		if(doc.is_return){
+			item.received_qty = item.qty;
+			item.rejected_qty = 0;
+		}
+		
 		this._super(doc, cdt, cdn);
 		this.conversion_factor(doc, cdt, cdn);
 


### PR DESCRIPTION
In a Purchase Receipt changing an item accepted qty will trigger changing rejected qty to complement received qty, this is the normal behavior but it's not the expected behavior when dealing with Return Purchase Receipt.

It makes partial purchase return looks like this (trying to return 1 from 5)

![before](https://cloud.githubusercontent.com/assets/1159471/22110035/f1fc9e62-de62-11e6-9134-456d83deaaf3.png)

rejected qty in a purchase return doesn't make sense and causes errors when validating quantity 

It should look like this instead

![after](https://cloud.githubusercontent.com/assets/1159471/22110505/9f31b076-de64-11e6-8412-108c01f71418.png)



